### PR TITLE
presentation and visualization page

### DIFF
--- a/content/presentation_and_visualization.Rmd
+++ b/content/presentation_and_visualization.Rmd
@@ -101,7 +101,7 @@ ggplot(data = penguins, mapping = aes(x = bill_length_mm, y = bill_depth_mm, col
   facet_wrap(~species)
 ```
 
-### Making Summary Tables in R
+### Making summary tables in R
 
 _yada yada about `kable`_
 


### PR DESCRIPTION
This PR builds off of #9.

I renamed the file and made some formatting edits to reflect the intro to `ggplot2` being situated in a "Presentation & Visualization" page, [based on the outline in the README](https://github.com/simonpcouch/data_at_reed/blob/ae887033abd46808fab33cc0958ddd45c219abaa/README.Rmd#L18-L33). The heading levels (i.e. number of `###`) now match those from #7, as well.

_Note: to make that hyperlink and link it to specific lines of code, I used the following code:_
```
[based on the outline in the README](https://github.com/simonpcouch/data_at_reed/blob/main/README.Rmd#L18-L33)
```

*To link to issues/PR, all you have to do is just type # and the number of the issue/PR, found at the end of its URL*

Related to #10.