### PR TITLE
add section on tibbles, delete head() calls

### DIFF
--- a/content/wrangling_data.Rmd
+++ b/content/wrangling_data.Rmd
@@ -13,10 +13,6 @@ library(knitr)
 
 When you first get a dataset, whether it's from a class, downloaded from the internet, or given to you by a professor, there might be ways that you want to change that data to make it easier to work with, add more information, or summarize your data. These all fall under the term "Data Wrangling". Let's learn how to handle our data, how to get more out of it, and how to keep it tidy.
 
-### Data Frames and `tibble`s
-
-<!-- _yada yada about data frames and tibbles_ - biggest thing to note here is that the print method (i.e. what happens when you just type the name of a data frame) is much better than that for normal data frames -->
-
 ### Tidy Data Principles, Reshaping Data, and `tidyr`
 
 Packages in the `tidyverse`, like `ggplot2` and `dplyr`, are built to work with tidy data. The `tidyr` package can help us tidy up a dataset by rearranging how data is structured.
@@ -93,8 +89,6 @@ If you're interested in learning more about tidy data and pivoting, we recommend
 Now that our data is tidy we can use `dplyr` to further transform our data!
 
 There are 6 fundamental `dpylr` functions that should allow you to perform the data wrangling that you find yourself needing to do. For the following examples we'll be using the full `penguins` data set.
-
-Whenever you see the `head()` function used, you can think of it as a way for us to take a peek at what our transformations are doing!
 
 First of all we can use it to get a feel for what our variables are and what their values might look like:
 
@@ -253,8 +247,7 @@ Here, we're filtering our data to only look at penguin species that start with t
 
 ```{r}
 penguins %>%
-  filter(str_detect(species, "^A") & str_detect(island, "m$")) %>%
-  head()
+  filter(str_detect(species, "^A") & str_detect(island, "m$"))
 ```
 
 If you're comfortable with `dplyr` you may be realizing that this is not the most efficient way to solve this problem as we could very easily use `filter(species == "Adelie" & island == "Dream")`, but if you were dealing with a data set that had text that wasn't split into factors, using `str_detect()` makes a lot of things possible.
@@ -265,8 +258,7 @@ This can be extended beyond just a letter, so that we can look for observations 
 
 ```{r}
 penguins %>%
-  filter(str_detect(species, "^Adeli")) %>%
-  head()
+  filter(str_detect(species, "^Adeli"))
 ```
 
 Next, we'll take a look at an example where we want to only look at species that end in 1 or 2 "o's", and then we use a helpful function called `str_to_upper()' to capitalize the names of those species:
@@ -274,8 +266,7 @@ Next, we'll take a look at an example where we want to only look at species that
 ```{r}
 penguins_edited <- penguins %>%
   filter(str_detect(species, "o{1,2}$"))%>%
-  mutate(species = str_to_upper(species)) %>%
-  head()
+  mutate(species = str_to_upper(species))
 
 penguins_edited
 ```
@@ -286,8 +277,7 @@ Following off of our previous code, we can then use a function called `str_remov
 
 ```{r}
 penguins_edited %>%
-  mutate(species = str_remove(species,"O{2}$")) %>%
-  head()
+  mutate(species = str_remove(species,"O{2}$"))
 ```
 
 This can be especially useful when you have observations that have a prefix or a suffix that you don't want.
@@ -299,8 +289,7 @@ The last function that we'll show here will be `str_replace()`. In this example 
 ```{r}
 penguins %>%
   filter(island == "Biscoe") %>%
-  mutate(island = str_replace(island, "e", "tti")) %>%
-  head()
+  mutate(island = str_replace(island, "e", "tti"))
 ```
 
 This is a somewhat silly example, but there are plenty of situations in which making replacements such as these will be important for a project you might be working on.
@@ -309,8 +298,300 @@ If you want to replace patterns more extensively, you can use `str_replace_all()
 
 ```{r}
 penguins %>%
-  mutate(species = str_replace_all(species, "[aeiou]", "x")) %>%
-  head()
+  mutate(species = str_replace_all(species, "[aeiou]", "x"))
 ```
 
 If you want to learn more about `stringr`, [the package's website](https://stringr.tidyverse.org/) contains a more extensive overview of the package and its functions. You might also check out the [Strings chapter](https://r4ds.had.co.nz/strings.html) of the R for Data Science book.
+
+### Data Frames and `tibble`s
+
+So far in this tutorial, we've exclusively worked with "tibbles". From the [`tibble` website](https://tibble.tidyverse.org/) 
+
+> A _tibble_, or `tbl_df`, is a modern reimagining of the `data.frame`, keeping what time has proven to be effective, and throwing out what is not. Tibbles are data.frames that are lazy and surly: they do less (i.e. they don’t change variable names or types, and don’t do partial matching) and complain more (e.g. when a variable does not exist). This forces you to confront problems earlier, typically leading to cleaner, more expressive code.
+
+If this sounds like gibberish to you, that's okay. The biggest benefit to `tibble`s over `data.frame`s is the way that they print. If we print `penguins` as a tibble, for example, the output looks like this:
+
+```{r, eval = FALSE}
+penguins
+
+# # A tibble: 344 x 8
+#    species island  bill_length_mm bill_depth_mm flipper_length_… body_mass_g sex    year
+#    <fct>   <fct>            <dbl>         <dbl>            <int>       <int> <fct> <int>
+#  1 Adelie  Torger…           39.1          18.7              181        3750 male   2007
+#  2 Adelie  Torger…           39.5          17.4              186        3800 fema…  2007
+#  3 Adelie  Torger…           40.3          18                195        3250 fema…  2007
+#  4 Adelie  Torger…           NA            NA                 NA          NA NA     2007
+#  5 Adelie  Torger…           36.7          19.3              193        3450 fema…  2007
+#  6 Adelie  Torger…           39.3          20.6              190        3650 male   2007
+#  7 Adelie  Torger…           38.9          17.8              181        3625 fema…  2007
+#  8 Adelie  Torger…           39.2          19.6              195        4675 male   2007
+#  9 Adelie  Torger…           34.1          18.1              193        3475 NA     2007
+# 10 Adelie  Torger…           42            20.2              190        4250 NA     2007
+# # … with 334 more rows
+```
+
+We can easily see the dimensions of the tibble (344 x 8), the variable names and their types, and the first ten rows. 
+
+In contrast, printing out a `data.frame` is a bit unwieldy:
+
+```{r, eval = FALSE}
+as.data.frame(penguins)
+
+#     species    island bill_length_mm bill_depth_mm flipper_length_mm body_mass_g    sex
+# 1    Adelie Torgersen           39.1          18.7               181        3750   male
+# 2    Adelie Torgersen           39.5          17.4               186        3800 female
+# 3    Adelie Torgersen           40.3          18.0               195        3250 female
+# 4    Adelie Torgersen             NA            NA                NA          NA   <NA>
+# 5    Adelie Torgersen           36.7          19.3               193        3450 female
+# 6    Adelie Torgersen           39.3          20.6               190        3650   male
+# 7    Adelie Torgersen           38.9          17.8               181        3625 female
+# 8    Adelie Torgersen           39.2          19.6               195        4675   male
+# 9    Adelie Torgersen           34.1          18.1               193        3475   <NA>
+# 10   Adelie Torgersen           42.0          20.2               190        4250   <NA>
+# 11   Adelie Torgersen           37.8          17.1               186        3300   <NA>
+# 12   Adelie Torgersen           37.8          17.3               180        3700   <NA>
+# 13   Adelie Torgersen           41.1          17.6               182        3200 female
+# 14   Adelie Torgersen           38.6          21.2               191        3800   male
+# 15   Adelie Torgersen           34.6          21.1               198        4400   male
+# 16   Adelie Torgersen           36.6          17.8               185        3700 female
+# 17   Adelie Torgersen           38.7          19.0               195        3450 female
+# 18   Adelie Torgersen           42.5          20.7               197        4500   male
+# 19   Adelie Torgersen           34.4          18.4               184        3325 female
+# 20   Adelie Torgersen           46.0          21.5               194        4200   male
+# 21   Adelie    Biscoe           37.8          18.3               174        3400 female
+# 22   Adelie    Biscoe           37.7          18.7               180        3600   male
+# 23   Adelie    Biscoe           35.9          19.2               189        3800 female
+# 24   Adelie    Biscoe           38.2          18.1               185        3950   male
+# 25   Adelie    Biscoe           38.8          17.2               180        3800   male
+# 26   Adelie    Biscoe           35.3          18.9               187        3800 female
+# 27   Adelie    Biscoe           40.6          18.6               183        3550   male
+# 28   Adelie    Biscoe           40.5          17.9               187        3200 female
+# 29   Adelie    Biscoe           37.9          18.6               172        3150 female
+# 30   Adelie    Biscoe           40.5          18.9               180        3950   male
+# 31   Adelie     Dream           39.5          16.7               178        3250 female
+# 32   Adelie     Dream           37.2          18.1               178        3900   male
+# 33   Adelie     Dream           39.5          17.8               188        3300 female
+# 34   Adelie     Dream           40.9          18.9               184        3900   male
+# 35   Adelie     Dream           36.4          17.0               195        3325 female
+# 36   Adelie     Dream           39.2          21.1               196        4150   male
+# 37   Adelie     Dream           38.8          20.0               190        3950   male
+# 38   Adelie     Dream           42.2          18.5               180        3550 female
+# 39   Adelie     Dream           37.6          19.3               181        3300 female
+# 40   Adelie     Dream           39.8          19.1               184        4650   male
+# 41   Adelie     Dream           36.5          18.0               182        3150 female
+# 42   Adelie     Dream           40.8          18.4               195        3900   male
+# 43   Adelie     Dream           36.0          18.5               186        3100 female
+# 44   Adelie     Dream           44.1          19.7               196        4400   male
+# 45   Adelie     Dream           37.0          16.9               185        3000 female
+# 46   Adelie     Dream           39.6          18.8               190        4600   male
+# 47   Adelie     Dream           41.1          19.0               182        3425   male
+# 48   Adelie     Dream           37.5          18.9               179        2975   <NA>
+# 49   Adelie     Dream           36.0          17.9               190        3450 female
+# 50   Adelie     Dream           42.3          21.2               191        4150   male
+# 51   Adelie    Biscoe           39.6          17.7               186        3500 female
+# 52   Adelie    Biscoe           40.1          18.9               188        4300   male
+# 53   Adelie    Biscoe           35.0          17.9               190        3450 female
+# 54   Adelie    Biscoe           42.0          19.5               200        4050   male
+# 55   Adelie    Biscoe           34.5          18.1               187        2900 female
+# 56   Adelie    Biscoe           41.4          18.6               191        3700   male
+# 57   Adelie    Biscoe           39.0          17.5               186        3550 female
+# 58   Adelie    Biscoe           40.6          18.8               193        3800   male
+# 59   Adelie    Biscoe           36.5          16.6               181        2850 female
+# 60   Adelie    Biscoe           37.6          19.1               194        3750   male
+# 61   Adelie    Biscoe           35.7          16.9               185        3150 female
+# 62   Adelie    Biscoe           41.3          21.1               195        4400   male
+# 63   Adelie    Biscoe           37.6          17.0               185        3600 female
+# 64   Adelie    Biscoe           41.1          18.2               192        4050   male
+# 65   Adelie    Biscoe           36.4          17.1               184        2850 female
+# 66   Adelie    Biscoe           41.6          18.0               192        3950   male
+# 67   Adelie    Biscoe           35.5          16.2               195        3350 female
+# 68   Adelie    Biscoe           41.1          19.1               188        4100   male
+# 69   Adelie Torgersen           35.9          16.6               190        3050 female
+# 70   Adelie Torgersen           41.8          19.4               198        4450   male
+# 71   Adelie Torgersen           33.5          19.0               190        3600 female
+# 72   Adelie Torgersen           39.7          18.4               190        3900   male
+# 73   Adelie Torgersen           39.6          17.2               196        3550 female
+# 74   Adelie Torgersen           45.8          18.9               197        4150   male
+# 75   Adelie Torgersen           35.5          17.5               190        3700 female
+# 76   Adelie Torgersen           42.8          18.5               195        4250   male
+# 77   Adelie Torgersen           40.9          16.8               191        3700 female
+# 78   Adelie Torgersen           37.2          19.4               184        3900   male
+# 79   Adelie Torgersen           36.2          16.1               187        3550 female
+# 80   Adelie Torgersen           42.1          19.1               195        4000   male
+# 81   Adelie Torgersen           34.6          17.2               189        3200 female
+# 82   Adelie Torgersen           42.9          17.6               196        4700   male
+# 83   Adelie Torgersen           36.7          18.8               187        3800 female
+# 84   Adelie Torgersen           35.1          19.4               193        4200   male
+# 85   Adelie     Dream           37.3          17.8               191        3350 female
+# 86   Adelie     Dream           41.3          20.3               194        3550   male
+# 87   Adelie     Dream           36.3          19.5               190        3800   male
+# 88   Adelie     Dream           36.9          18.6               189        3500 female
+# 89   Adelie     Dream           38.3          19.2               189        3950   male
+# 90   Adelie     Dream           38.9          18.8               190        3600 female
+# 91   Adelie     Dream           35.7          18.0               202        3550 female
+# 92   Adelie     Dream           41.1          18.1               205        4300   male
+# 93   Adelie     Dream           34.0          17.1               185        3400 female
+# 94   Adelie     Dream           39.6          18.1               186        4450   male
+# 95   Adelie     Dream           36.2          17.3               187        3300 female
+# 96   Adelie     Dream           40.8          18.9               208        4300   male
+# 97   Adelie     Dream           38.1          18.6               190        3700 female
+# 98   Adelie     Dream           40.3          18.5               196        4350   male
+# 99   Adelie     Dream           33.1          16.1               178        2900 female
+# 100  Adelie     Dream           43.2          18.5               192        4100   male
+# 101  Adelie    Biscoe           35.0          17.9               192        3725 female
+# 102  Adelie    Biscoe           41.0          20.0               203        4725   male
+# 103  Adelie    Biscoe           37.7          16.0               183        3075 female
+# 104  Adelie    Biscoe           37.8          20.0               190        4250   male
+# 105  Adelie    Biscoe           37.9          18.6               193        2925 female
+# 106  Adelie    Biscoe           39.7          18.9               184        3550   male
+# 107  Adelie    Biscoe           38.6          17.2               199        3750 female
+# 108  Adelie    Biscoe           38.2          20.0               190        3900   male
+# 109  Adelie    Biscoe           38.1          17.0               181        3175 female
+# 110  Adelie    Biscoe           43.2          19.0               197        4775   male
+# 111  Adelie    Biscoe           38.1          16.5               198        3825 female
+# 112  Adelie    Biscoe           45.6          20.3               191        4600   male
+# 113  Adelie    Biscoe           39.7          17.7               193        3200 female
+# 114  Adelie    Biscoe           42.2          19.5               197        4275   male
+# 115  Adelie    Biscoe           39.6          20.7               191        3900 female
+# 116  Adelie    Biscoe           42.7          18.3               196        4075   male
+# 117  Adelie Torgersen           38.6          17.0               188        2900 female
+# 118  Adelie Torgersen           37.3          20.5               199        3775   male
+# 119  Adelie Torgersen           35.7          17.0               189        3350 female
+# 120  Adelie Torgersen           41.1          18.6               189        3325   male
+# 121  Adelie Torgersen           36.2          17.2               187        3150 female
+# 122  Adelie Torgersen           37.7          19.8               198        3500   male
+# 123  Adelie Torgersen           40.2          17.0               176        3450 female
+# 124  Adelie Torgersen           41.4          18.5               202        3875   male
+# 125  Adelie Torgersen           35.2          15.9               186        3050 female
+#     year
+# 1   2007
+# 2   2007
+# 3   2007
+# 4   2007
+# 5   2007
+# 6   2007
+# 7   2007
+# 8   2007
+# 9   2007
+# 10  2007
+# 11  2007
+# 12  2007
+# 13  2007
+# 14  2007
+# 15  2007
+# 16  2007
+# 17  2007
+# 18  2007
+# 19  2007
+# 20  2007
+# 21  2007
+# 22  2007
+# 23  2007
+# 24  2007
+# 25  2007
+# 26  2007
+# 27  2007
+# 28  2007
+# 29  2007
+# 30  2007
+# 31  2007
+# 32  2007
+# 33  2007
+# 34  2007
+# 35  2007
+# 36  2007
+# 37  2007
+# 38  2007
+# 39  2007
+# 40  2007
+# 41  2007
+# 42  2007
+# 43  2007
+# 44  2007
+# 45  2007
+# 46  2007
+# 47  2007
+# 48  2007
+# 49  2007
+# 50  2007
+# 51  2008
+# 52  2008
+# 53  2008
+# 54  2008
+# 55  2008
+# 56  2008
+# 57  2008
+# 58  2008
+# 59  2008
+# 60  2008
+# 61  2008
+# 62  2008
+# 63  2008
+# 64  2008
+# 65  2008
+# 66  2008
+# 67  2008
+# 68  2008
+# 69  2008
+# 70  2008
+# 71  2008
+# 72  2008
+# 73  2008
+# 74  2008
+# 75  2008
+# 76  2008
+# 77  2008
+# 78  2008
+# 79  2008
+# 80  2008
+# 81  2008
+# 82  2008
+# 83  2008
+# 84  2008
+# 85  2008
+# 86  2008
+# 87  2008
+# 88  2008
+# 89  2008
+# 90  2008
+# 91  2008
+# 92  2008
+# 93  2008
+# 94  2008
+# 95  2008
+# 96  2008
+# 97  2008
+# 98  2008
+# 99  2008
+# 100 2008
+# 101 2009
+# 102 2009
+# 103 2009
+# 104 2009
+# 105 2009
+# 106 2009
+# 107 2009
+# 108 2009
+# 109 2009
+# 110 2009
+# 111 2009
+# 112 2009
+# 113 2009
+# 114 2009
+# 115 2009
+# 116 2009
+# 117 2009
+# 118 2009
+# 119 2009
+# 120 2009
+# 121 2009
+# 122 2009
+# 123 2009
+# 124 2009
+# 125 2009
+#  [ reached 'max' / getOption("max.print") -- omitted 219 rows ]
+```
+
+In these tutorials, we make use of `tibble`s rather than `data.frame`s, and encourage you to do so as well.
+
+If you want to learn more about `tibble`s, [the package's website](https://tibble.tidyverse.org/) contains a more extensive overview of the package and its functionality.


### PR DESCRIPTION
This PR adds a short section on `tibble`s vs `data.frame`s! I also deleted calls to `head()` earlier on in the tutorial, as, since we're working with a `tibble` already, the output will print 10 rows (`head()` prints 6, `data.frame`s print the whole thing).

The line count is due to the lines of printed output. :-)

Related to #32.