### PR TITLE
add links out for advanced wrangling topics

### DIFF
--- a/03-wrangling-data/advanced_wrangling.Rmd
+++ b/03-wrangling-data/advanced_wrangling.Rmd
@@ -1,0 +1,34 @@
+---
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(palmerpenguins)
+library(tidyverse)
+library(knitr)
+```
+
+### Advanced data wrangling
+
+Throughout the pages in the Wrangling Data section of these tutorials, we've introduced all sorts of ways to transform, manipulate, and reshape data. These tools will be more than enough to handle many data analysis projects. If you're looking to learn more, though, we wanted to compile some links out to resources we particularly appreciate.
+
+#### Doing things many times with `purrr`
+
+In R, there are many ways of doing things many times---you may or may not have heard of `for` loops, the `apply` family, or `map`ping functions. The tidy approach to running a function many times, or "iterating," is implemented in the `purrr` package via `map` functions. [Dr. Rebecca Barter](http://www.rebeccabarter.com/) wrote a wonderful [introduction to `purrr`](http://www.rebeccabarter.com/blog/2019-08-19_purrr/) that we recommend if you want to learn about vectors, lists, data frames, and iterating over them. To learn more about iteration, generally, check out the [R for Data Science](https://r4ds.had.co.nz/iteration.html) chapter on the topic.
+
+#### Writing your own functions
+
+As you do more data analysis, you may find yourself finding uses for the same code time and time again. Rather than copying and pasting each time you need that code, you could instead automate that task by writing your own _function_. The [R for Data Science](https://r4ds.had.co.nz/index.html) book outlines three advantages of writing a custom function over copying and pasting that we quote here:
+
+> 1) You can give a function an evocative name that makes your code easier to understand.
+> 
+> 2) As requirements change, you only need to update code in one place, instead of many.
+> 
+> 3) You eliminate the chance of making incidental mistakes when you copy and paste (i.e. updating a variable name in one place, but not in another).
+
+We recommend the [R4DS Chapter](https://r4ds.had.co.nz/functions.html) if you're interested in learning more about writing your own functions!
+
+#### Working with time and date data with `lubridate`
+
+If you've come across time and/or date data while working on a data analysis, you may have found it trickier than expected. As the relevant [R for Data Science chapter](https://r4ds.had.co.nz/dates-and-times.html) notes about dates and times: "You use them all the time in your regular life, and they don’t seem to cause much confusion. However, the more you learn about dates and times, the more complicated they seem to get." We recommend the chapter linked above if you need to work with time and/or data and don't know where to get started.


### PR DESCRIPTION
This PR adds an "advanced wrangling" page (to be dropped in at the end of the Data Wrangling pages) that links out to external resources. For now, this includes `purrr`/iteration, writing functions, and lubridate. I think #51 could be relevant here as well if folks that this is an appropriate scope for that section and are game to add another subsection!

This approach means that people looking for a specific package name or analysis technique from the [main page](https://www.reed.edu/data-at-reed/resources/R/index.html) wouldn't be able to see it, unfortunately.

Closes #48. Closes #49.