### PR TITLE
use consistent function alias

### DIFF
--- a/03-wrangling-data/summarizing_data.Rmd
+++ b/03-wrangling-data/summarizing_data.Rmd
@@ -27,7 +27,7 @@ With the grouping defined, apply the `summarize()` function to calculate mean bo
 ```{r message = FALSE}
 penguins %>%
   group_by(island) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
 ```
 
 Missing values (`NA`) are an important consideration in data analysis. In the above code, the `na.rm = TRUE` removes any missing values in `body_mass_g` so R is free to calculate the mean of the body mass data that is in the dataset. (To experiment with the effect of `na.rm = TRUE`, run the above code without that argument.)
@@ -37,5 +37,5 @@ You can extend the above approach to group by _both_ island and year:
 ```{r message = FALSE}
 penguins %>%
   group_by(island, year) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
 ```

--- a/03-wrangling-data/wrangling_data.Rmd
+++ b/03-wrangling-data/wrangling_data.Rmd
@@ -250,7 +250,7 @@ With the grouping defined, apply the `summarize()` function to calculate mean bo
 ```{r message = FALSE}
 penguins %>%
   group_by(island) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
 ```
 
 Missing values (`NA`) are an important consideration in data analysis. In the above code, the `na.rm = TRUE` removes any missing values in `body_mass_g` so R is free to calculate the mean of the body mass data that is in the dataset. (To experiment with the effect of `na.rm = TRUE`, run the above code without that argument.)
@@ -260,7 +260,7 @@ You can extend the above approach to group by _both_ island and year:
 ```{r message = FALSE}
 penguins %>%
   group_by(island, year) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
 ```
 
 ---

--- a/04-presentation-visualization/presentation_and_visualization.Rmd
+++ b/04-presentation-visualization/presentation_and_visualization.Rmd
@@ -330,7 +330,7 @@ Here is the code for our summary statistic, which we will save in a new dataset 
 ```{r message = FALSE}
 penguin_sum <- penguins %>%
   group_by(island, year) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
 ```
 
 You can print the dataset within R/RStudio:

--- a/04-presentation-visualization/summary_tables.Rmd
+++ b/04-presentation-visualization/summary_tables.Rmd
@@ -35,7 +35,7 @@ Here is the code for our summary statistic, which we will save in a new dataset 
 ```{r message = FALSE}
 penguin_sum <- penguins %>%
   group_by(island, year) %>%
-  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE)) %>% 
+  summarize(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE)) %>% 
   ungroup()
 ```
 

--- a/05-more-resources/troubleshooting.Rmd
+++ b/05-more-resources/troubleshooting.Rmd
@@ -141,7 +141,7 @@ Sometimes errors can arise when you compute summary statistics on a dataset. Her
 
 ```{r}
 penguins %>%
-  summarise(mean_bill_length = mean(bill_length_mm),
+  summarize(mean_bill_length = mean(bill_length_mm),
             mean_body_mass = mean(body_mass_g))
 ```
 
@@ -149,7 +149,7 @@ The resulting dataset shows `NA` values where our means should be. This happens 
 
 ```{r}
 penguins %>%
-  summarise(mean_bill_length = mean(bill_length_mm, na.rm = TRUE),
+  summarize(mean_bill_length = mean(bill_length_mm, na.rm = TRUE),
             mean_body_mass = mean(body_mass_g, na.rm = TRUE))
 ```
 


### PR DESCRIPTION
Can't think of any other instances of this right now, but we should make sure that when a function is aliased (i.e. `summarize()` and `summarise()` are the same function), we should only use one of them throughout the docs. I don't have a preference for which spelling we use, though this first go changes all instances of `summarise` to `summarize`.

For posterity, the procedure here was Cmd + Shift + F in RStudio, search for `summarise(`, replace with `summarize(`.🐞